### PR TITLE
Fix spacing and Markdown capitalization in KaTeX article

### DIFF
--- a/content/posts/use-katex-in-hugo.md
+++ b/content/posts/use-katex-in-hugo.md
@@ -4,15 +4,15 @@ date = "2019-08-12"
 description = "Hugo で構築したブログで [KaTeX](https://katex.org/) を使った数式組版を行いたいが、よく使われている auto-render extension を使う方式だとエスケープの問題がある。そこで、Hugo の shortcode を経由することでエスケープの問題を回避する。"
 +++
 
-!!! 注意: このブログは以前Hugoでビルドしていたが、[現在はzolaに移行済み](@/posts/renew-this-blog.md)のため、この記事の数式レンダリング部分の一部は動かなくなっている。!!!
+!!! 注意: このブログは以前 Hugo でビルドしていたが、[現在は zola に移行済み](@/posts/renew-this-blog.md)のため、この記事の数式レンダリング部分の一部は動かなくなっている。!!!
 
 ## KaTeX の auto-render extension を使う方式
 
 [Auto-render extension](https://katex.org/docs/autorender.html) という機能で、`$$` などで挟んだ LaTeX コードをレンダリングすることができるが、エスケープ周りにちょっと問題がある。
 
-例えば、`$[a](b)$` の $ で挟まれた中身は通常の KaTeX でも有効な LaTeX コードだが、一旦 markdown パーサーを通してしまうと `$<a href="b">a</a>$` と解釈されてしまい、意図しない表示になってしまう。
+例えば、`$[a](b)$` の $ で挟まれた中身は通常の KaTeX でも有効な LaTeX コードだが、一旦 Markdown パーサーを通してしまうと `$<a href="b">a</a>$` と解釈されてしまい、意図しない表示になってしまう。
 
-これは極端な例なのでは？という気もするが、markdown パーサーに意図せず変換されてしまう例は、他にも下記のようにいくつか考えられる。
+これは極端な例なのでは？という気もするが、Markdown パーサーに意図せず変換されてしまう例は、他にも下記のようにいくつか考えられる。
 
 - `$a _{b_ c}$`
 - `$a *b* c$`
@@ -20,10 +20,10 @@ description = "Hugo で構築したブログで [KaTeX](https://katex.org/) を�
 
 長めの式を書いていて気づかないうちにこの手のエラーに引っかかると、原因の特定だけでかなり時間を消費してしまうので、なんとかして防ぎたい。
 
-* [KaTeXの数式をLaTeXの\\\[...\\\]と$...$で記述し，それをHugoで生成するページで表示する \- Qiita](https://qiita.com/mametank/items/fa2b8a03598c9548e461)
+* [KaTeX の数式を LaTeX の\\\[...\\\] と $...$ で記述し，それを Hugo で生成するページで表示する \- Qiita](https://qiita.com/mametank/items/fa2b8a03598c9548e461)
   - あきらめてエスケープで我慢している
 * [Hugo meets kramdown \+ KaTeX \#gohugo \| takuti\.me](https://takuti.me/note/hugo-kramdown-and-katex/)
-  - markdown パーサーを差し替えて回避している
+  - Markdown パーサーを差し替えて回避している
 
 
 ## Shortcodes を使う方式
@@ -44,7 +44,7 @@ layouts/shortcodes/eq-display.html:
 
 後から CSS で参照する都合上、displaystyle をクラスに追加しておいたが、別に必須ではない。
 
-数式を入れたページで通常通り KaTeX のファイルをロードしつつ、下記のようなJSを実行すれば数式が表示される。
+数式を入れたページで通常通り KaTeX のファイルをロードしつつ、下記のような JS を実行すれば数式が表示される。
 
 ```js
 (function() {
@@ -78,5 +78,5 @@ See how it renders with {{<eq "\KaTeX">}}:
 >    \,d\xi
 >{{< /eq-display >}}
 
-ただし、auto-render extension 方式に比べると明らかに記法が煩雑なので、こちらの方式がかならずしも良いとは言い切れない。
+ただし、auto-render extension 方式に比べると明らかに記法が煩雑なので、こちらの方式が必ずしも良いとは言い切れない。
 簡潔だがたまにエスケープで厄介なことになる記法を好むか、煩雑だがエスケープの問題がない記法を好むか、好みが分かれるかなと思う。


### PR DESCRIPTION
## Summary
- insert spaces between Japanese and English terms in KaTeX article
- capitalize "Markdown" and fix "必ずしも" wording

## Testing
- `zola build` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8cd51078832ba837536243abd788