### PR TITLE
Avoid nested selectors for the table of contents

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -87,7 +87,6 @@ code:not([data-lang]) {
     background-color: #0f1419;
 }
 
-/* explicit selectors for better browser support */
 .tableofcontent > p {
     margin-bottom: 0;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -87,13 +87,13 @@ code:not([data-lang]) {
     background-color: #0f1419;
 }
 
-.tableofcontent {
-    > p {
-        margin-bottom: 0;
-    }
-    > ul {
-        margin-top: 0;
-    }
+/* explicit selectors for better browser support */
+.tableofcontent > p {
+    margin-bottom: 0;
+}
+
+.tableofcontent > ul {
+    margin-top: 0;
 }
 
 blockquote {


### PR DESCRIPTION
## Summary
- switch `.tableofcontent` rules to explicit child selectors for better browser support
- document the selectors with a compatibility comment

## Testing
- `zola build` *(fails: command not found: zola)*

------
https://chatgpt.com/codex/tasks/task_e_68b07db47304832b9451eb9a1c0aee6b