### PR TITLE
Update site base URL to production domain

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://oshikiri.github.io"
+base_url = "https://oshikiri.org"
 
 [markdown]
 highlight_code = true


### PR DESCRIPTION
## Summary
- point `base_url` to `https://oshikiri.org`

## Testing
- `zola build` *(fails: command not found)*
- `apt-get update` *(fails: repository unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_68adc2c5bcd4832b9f38cfafa8a360e1