### PR TITLE
docs: clarify deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ zola serve
 ```
 
 ## Deployment
-Push a new commit to the master branch and then `build-deploy` workflow will build and deploy the commit.
+Push a new commit to the master branch, and the `build-deploy` workflow will build and deploy it.


### PR DESCRIPTION
## Summary
- clarify deployment sentence in README

## Testing
- `zola build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7eb78db8832ba042197d8d852041